### PR TITLE
(SIMP-1450) Deconflict 'concat' and 'apache'

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 ---
 fixtures:
   repositories:
-    apache: "https://github.com/simp/pupmod-simp-apache"
+    simp_apache: "https://github.com/simp/pupmod-simp-apache"
     auditd: "https://github.com/simp/pupmod-simp-auditd"
     iptables: "https://github.com/simp/pupmod-simp-iptables"
     logrotate: "https://github.com/simp/pupmod-simp-logrotate"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
+- Updated to work with the deconflicted 'simp_apache' and 'simpcat' modules.
+
 * Mon Mar 14 2016 Trevor Vaughan <tvaughan@onxypoint.com> - 5.0.0-0
 - Updated to be compatible with the Puppet 4 inline template function call
   requirements.

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,4 +1,4 @@
-Requires: pupmod-simp-apache >= 2.0.0-0
-Requires: pupmod-simp-simpcat >= 2.1.0-1
+Requires: pupmod-simp-apache >= 5.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Requires: pupmod-simp-iptables >= 2.0.0-0
 Obsoletes: pupmod-ganglia-test

--- a/manifests/meta.pp
+++ b/manifests/meta.pp
@@ -27,7 +27,7 @@ class ganglia::meta {
     }
   }
 
-  concat_build { 'gmetad':
+  simpcat_build { 'gmetad':
     target  => '/etc/ganglia/gmetad.conf',
     order   => ['*.conf'],
     require => File['/etc/ganglia']
@@ -39,7 +39,7 @@ class ganglia::meta {
     mode      => '0644',
     audit     => content,
     notify    => Service['gmetad'],
-    subscribe => Concat_build['gmetad']
+    subscribe => Simpcat_build['gmetad']
   }
 
   # Simply allow blanket IGMP...when you need it, you need it.

--- a/manifests/meta/add_data_source.pp
+++ b/manifests/meta/add_data_source.pp
@@ -34,7 +34,7 @@ define ganglia::meta::add_data_source (
   else {
     $ds_id = $data_source_id
   }
-  concat_fragment { "gmetad+data_source_${name}.conf":
+  simpcat_fragment { "gmetad+data_source_${name}.conf":
     content => template('ganglia/gmetad/data_source.erb')
   }
 }

--- a/manifests/meta/conf.pp
+++ b/manifests/meta/conf.pp
@@ -53,7 +53,7 @@ class ganglia::meta::conf (
 ) {
   include 'ganglia::meta'
 
-  concat_fragment { 'gmetad+meta.conf':
+  simpcat_fragment { 'gmetad+meta.conf':
     content => template('ganglia/gmetad/conf.erb')
   }
 }

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -41,7 +41,7 @@ class ganglia::monitor {
     require    => Package['ganglia-gmond']
   }
 
-  concat_build { 'gmond':
+  simpcat_build { 'gmond':
     order  => ['*.conf'],
     target => '/etc/ganglia/gmond.conf'
   }
@@ -51,7 +51,7 @@ class ganglia::monitor {
     group     => 'root',
     mode      => '0644',
     audit     => content,
-    subscribe => Concat_build['gmond'],
+    subscribe => Simpcat_build['gmond'],
     notify    => Service['gmond']
   }
 }

--- a/manifests/monitor/add_includes.pp
+++ b/manifests/monitor/add_includes.pp
@@ -18,7 +18,7 @@ class ganglia::monitor::add_includes (
 ) {
   include 'ganglia::monitor'
 
-  concat_fragment { 'gmond+includes.conf':
+  simpcat_fragment { 'gmond+includes.conf':
     content => template('ganglia/gmond/includes.erb')
   }
 }

--- a/manifests/monitor/cluster.pp
+++ b/manifests/monitor/cluster.pp
@@ -23,7 +23,7 @@ class ganglia::monitor::cluster (
 ) {
   include 'ganglia::monitor'
 
-  concat_fragment { 'gmond+cluster.conf':
+  simpcat_fragment { 'gmond+cluster.conf':
     content => template('ganglia/gmond/cluster.erb')
   }
 }

--- a/manifests/monitor/collection_group.pp
+++ b/manifests/monitor/collection_group.pp
@@ -9,8 +9,8 @@
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class ganglia::monitor::collection_group {
-  $fragdir = fragmentdir('gmond')
-  concat_build { 'gmond_cg':
+  $fragdir = simpcat_fragmentdir('gmond')
+  simpcat_build { 'gmond_cg':
     order        => [ '*.cg' ],
     target       => "$fragdir/collection_group.conf",
     parent_build => 'gmond'

--- a/manifests/monitor/collection_group/add_metric.pp
+++ b/manifests/monitor/collection_group/add_metric.pp
@@ -26,7 +26,7 @@ define ganglia::monitor::collection_group::add_metric (
 ) {
   include 'ganglia::monitor::collection_group'
 
-  concat_fragment { "gmond_cg+${collection_group_name}_5_${name}_metric.cg":
+  simpcat_fragment { "gmond_cg+${collection_group_name}_5_${name}_metric.cg":
     content => template('ganglia/gmond/collection_metric.erb'),
   }
 }

--- a/manifests/monitor/collection_group/conf.pp
+++ b/manifests/monitor/collection_group/conf.pp
@@ -24,14 +24,14 @@ define ganglia::monitor::collection_group::conf (
 ) {
   include 'ganglia::monitor::collection_group'
 
-  concat_fragment { "gmond_cg+${name}_0_begin.cg":
+  simpcat_fragment { "gmond_cg+${name}_0_begin.cg":
     content => 'collection_group {
 '
   }
-  concat_fragment { "gmond_cg+${name}_1_conf.cg":
+  simpcat_fragment { "gmond_cg+${name}_1_conf.cg":
     content => template('ganglia/gmond/collection_group.erb')
   }
-  concat_fragment { "gmond_cg+${name}_9_end.cg":
+  simpcat_fragment { "gmond_cg+${name}_9_end.cg":
     content => '}
 '
   }

--- a/manifests/monitor/globals.pp
+++ b/manifests/monitor/globals.pp
@@ -39,7 +39,7 @@ class ganglia::monitor::globals (
 ) {
   include 'ganglia::monitor'
 
-  concat_fragment { 'gmond+globals.conf':
+  simpcat_fragment { 'gmond+globals.conf':
     content => template('ganglia/gmond/globals.erb')
   }
 }

--- a/manifests/monitor/host.pp
+++ b/manifests/monitor/host.pp
@@ -13,7 +13,7 @@ class ganglia::monitor::host (
 ) {
   include 'ganglia::monitor'
 
-  concat_fragment { 'gmond+host.conf':
+  simpcat_fragment { 'gmond+host.conf':
     content => template('ganglia/gmond/host.erb')
   }
 }

--- a/manifests/monitor/mods.pp
+++ b/manifests/monitor/mods.pp
@@ -5,17 +5,17 @@
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class ganglia::monitor::mods {
-  $fragdir = fragmentdir('gmond')
-  concat_build { 'gmond_mods':
+  $fragdir = simpcat_fragmentdir('gmond')
+  simpcat_build { 'gmond_mods':
     order        => ['begin', '*.module', 'end'],
     target       => "$fragdir/modules.conf",
     parent_build => 'gmond'
   }
-  concat_fragment { 'gmond_mods+begin':
+  simpcat_fragment { 'gmond_mods+begin':
     content => 'modules {
 '
   }
-  concat_fragment { 'gmond_mods+end':
+  simpcat_fragment { 'gmond_mods+end':
     content => '}
 '
   }

--- a/manifests/monitor/mods/add_module.pp
+++ b/manifests/monitor/mods/add_module.pp
@@ -29,7 +29,7 @@ define ganglia::monitor::mods::add_module (
 ) {
   include 'ganglia::monitor::mods'
 
-  concat_fragment { "gmond_mods+${name}.module":
+  simpcat_fragment { "gmond_mods+${name}.module":
     content => template('ganglia/gmond/module.erb')
   }
 }

--- a/manifests/monitor/tcp_accept_channel.pp
+++ b/manifests/monitor/tcp_accept_channel.pp
@@ -8,8 +8,8 @@
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class ganglia::monitor::tcp_accept_channel {
-  $fragdir = fragmentdir('gmond')
-  concat_build { 'gmond_tcp_accept':
+  $fragdir = simpcat_fragmentdir('gmond')
+  simpcat_build { 'gmond_tcp_accept':
     target       => "$fragdir/tcp_accept_channel.conf",
     parent_build => 'gmond'
   }

--- a/manifests/monitor/tcp_accept_channel/add_acl.pp
+++ b/manifests/monitor/tcp_accept_channel/add_acl.pp
@@ -21,12 +21,12 @@ define ganglia::monitor::tcp_accept_channel::add_acl(
 ) {
   include 'ganglia::monitor::tcp_accept_channel'
 
-  concat_fragment { "gmond_tcp_accept+${tcp_accept_name}_4_acl_begin":
+  simpcat_fragment { "gmond_tcp_accept+${tcp_accept_name}_4_acl_begin":
     content => "  acl {
     default = \"$acl_default\"
 "
   }
-  concat_fragment { "gmond_tcp_accept+${tcp_accept_name}_6_acl_end":
+  simpcat_fragment { "gmond_tcp_accept+${tcp_accept_name}_6_acl_end":
     content => '  }
 '
   }

--- a/manifests/monitor/tcp_accept_channel/add_acl_access.pp
+++ b/manifests/monitor/tcp_accept_channel/add_acl_access.pp
@@ -50,7 +50,7 @@ define ganglia::monitor::tcp_accept_channel::add_acl_access(
       dports      => $tcp_accept_port
     }
   }
-  concat_fragment { "gmond_tcp_accept+${tcp_accept_name}_5_$access_file_name":
+  simpcat_fragment { "gmond_tcp_accept+${tcp_accept_name}_5_$access_file_name":
     content => template('ganglia/gmond/acl_access.erb')
   }
 

--- a/manifests/monitor/tcp_accept_channel/conf.pp
+++ b/manifests/monitor/tcp_accept_channel/conf.pp
@@ -30,15 +30,15 @@ define ganglia::monitor::tcp_accept_channel::conf (
 ) {
   include 'ganglia::monitor::tcp_accept_channel'
 
-  concat_fragment { "gmond_tcp_accept+${name}_0_begin":
+  simpcat_fragment { "gmond_tcp_accept+${name}_0_begin":
     content => 'tcp_accept_channel {
 '
   }
-  concat_fragment { "gmond_tcp_accept+${name}_9_end":
+  simpcat_fragment { "gmond_tcp_accept+${name}_9_end":
     content => '}
 '
   }
-  concat_fragment { "gmond_tcp_accept+${name}_1_conf":
+  simpcat_fragment { "gmond_tcp_accept+${name}_1_conf":
     content => template('ganglia/gmond/tcp_accept_channel.erb')
   }
 

--- a/manifests/monitor/udp_recv_channel.pp
+++ b/manifests/monitor/udp_recv_channel.pp
@@ -8,8 +8,8 @@
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class ganglia::monitor::udp_recv_channel {
-  $fragdir = fragmentdir('gmond')
-  concat_build { 'gmond_udp_recv':
+  $fragdir = simpcat_fragmentdir('gmond')
+  simpcat_build { 'gmond_udp_recv':
     target       => "$fragdir/udp_recv_channel.conf",
     parent_build => 'gmond'
   }

--- a/manifests/monitor/udp_recv_channel/add_acl.pp
+++ b/manifests/monitor/udp_recv_channel/add_acl.pp
@@ -21,12 +21,12 @@ define ganglia::monitor::udp_recv_channel::add_acl(
 ) {
   include 'ganglia::monitor::udp_recv_channel'
 
-  concat_fragment { "gmond_udp_recv+${udp_recv_name}_4_acl_begin":
+  simpcat_fragment { "gmond_udp_recv+${udp_recv_name}_4_acl_begin":
     content => "  acl {
     default = \"$acl_default\"
 "
   }
-  concat_fragment { "gmond_udp_recv+${udp_recv_name}_6_acl_end":
+  simpcat_fragment { "gmond_udp_recv+${udp_recv_name}_6_acl_end":
     content => '  }
 '
   }

--- a/manifests/monitor/udp_recv_channel/add_acl_access.pp
+++ b/manifests/monitor/udp_recv_channel/add_acl_access.pp
@@ -51,7 +51,7 @@ define ganglia::monitor::udp_recv_channel::add_acl_access(
       dports      => $udp_recv_port
     }
   }
-  concat_fragment { "gmond_udp_recv+${udp_recv_name}_5_${access_file_name}":
+  simpcat_fragment { "gmond_udp_recv+${udp_recv_name}_5_${access_file_name}":
     content => template('ganglia/gmond/acl_access.erb')
   }
 

--- a/manifests/monitor/udp_recv_channel/conf.pp
+++ b/manifests/monitor/udp_recv_channel/conf.pp
@@ -30,15 +30,15 @@ define ganglia::monitor::udp_recv_channel::conf (
 ) {
   include 'ganglia::monitor::udp_recv_channel'
 
-  concat_fragment { "gmond_udp_recv+${name}_0_begin":
+  simpcat_fragment { "gmond_udp_recv+${name}_0_begin":
     content => 'udp_recv_channel {
 '
   }
-  concat_fragment { "gmond_udp_recv+${name}_9_end":
+  simpcat_fragment { "gmond_udp_recv+${name}_9_end":
     content => '}
 '
   }
-  concat_fragment { "gmond_udp_recv+${name}_1_conf":
+  simpcat_fragment { "gmond_udp_recv+${name}_1_conf":
     content => template('ganglia/gmond/udp_recv_channel.erb')
   }
 

--- a/manifests/monitor/udp_send_channel.pp
+++ b/manifests/monitor/udp_send_channel.pp
@@ -29,7 +29,7 @@ define ganglia::monitor::udp_send_channel (
 ) {
   include 'ganglia::monitor'
 
-  concat_fragment { "gmond+${name}_udp_send_channel.conf":
+  simpcat_fragment { "gmond+${name}_udp_send_channel.conf":
     content => template('ganglia/gmond/udp_send_channel.erb')
   }
 }

--- a/manifests/web/add_user.pp
+++ b/manifests/web/add_user.pp
@@ -24,13 +24,13 @@ define ganglia::web::add_user (
   $realm = ''
 ){
 
-  if !defined(Concat_build['gweb']) {
-    concat_build { 'gweb':
+  if !defined(Simpcat_build['gweb']) {
+    simpcat_build { 'gweb':
       order => ['*.user']
     }
   }
 
-  concat_fragment { "gweb+$name.user":
+  simpcat_fragment { "gweb+$name.user":
     content => template('ganglia/web/user.erb')
   }
 }

--- a/manifests/web/conf.pp
+++ b/manifests/web/conf.pp
@@ -117,13 +117,13 @@ class ganglia::web::conf (
     content => template('ganglia/web/apache.erb')
   }
 
-  $outfile = concat_output('gweb')
+  $outfile = simpcat_output('gweb')
   file { $auth_user_file:
     owner   => 'root',
     group   => 'apache',
     mode    => '0640',
     source  => "file://${outfile}",
-    require => Concat_build['gweb']
+    require => Simpcat_build['gweb']
   }
 
   iptables::add_tcp_stateful_listen { 'allow_ganglia':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-ganglia",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "author":  "simp",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",
@@ -10,8 +10,8 @@
   "tags": [ "simp", "profiles"],
   "dependencies": [
     {
-      "name": "simp/apache",
-      "version_requirement": ">= 2.0.0"
+      "name": "simp/simp_apache",
+      "version_requirement": ">= 5.0.0"
     },
     {
       "name": "simp/iptables",
@@ -19,7 +19,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 2.1.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
This update uses the deconflicted 'concat' and 'simp_apache' modules.

SIMP-1450 #comment Deconflict with 'concat' and 'apache'
SIMP-6 #comment Deconflicted 'ganglia'
SIMP-843 #comment Deconflicted 'ganglia'
