### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,4 +1,11 @@
-Requires: pupmod-simp-apache >= 2.0.0-0
-Requires: pupmod-simp-simpcat >= 2.1.0-1
-Requires: pupmod-simp-iptables >= 2.0.0-0
 Obsoletes: pupmod-ganglia-test
+Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
+Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
+Requires: pupmod-simp-apache < 5.0.0-0
+Requires: pupmod-simp-apache >= 4.1.6-0
+Requires: pupmod-simp-iptables < 5.0.0-0
+Requires: pupmod-simp-iptables >= 4.1.4-0
+Requires: pupmod-simp-simpcat < 6.0.0-0
+Requires: pupmod-simp-simpcat >= 5.0.1-0
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,33 +1,37 @@
 {
-  "name":    "simp-ganglia",
-  "version": "5.0.0",
-  "author":  "simp",
+  "name": "simp-ganglia",
+  "version": "5.0.1",
+  "author": "simp",
   "summary": "default profiles for core SIMP installations",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-ganglia",
+  "source": "https://github.com/simp/pupmod-simp-ganglia",
   "project_page": "https://github.com/simp/pupmod-simp-ganglia",
-  "issues_url":   "https://simp/project.atlassian.net",
-  "tags": [ "simp", "profiles"],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "ganglia",
+    "monitoring"
+  ],
   "dependencies": [
     {
       "name": "simp/apache",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 4.1.6 < 5.0.0"
     },
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 4.1.4 < 5.0.0"
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 2.1.0"
+      "version_requirement": ">= 5.0.1 < 6.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.2.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.9.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-ganglia`
SIMP-1655 #close
