### PR TITLE
(SIMP-1732) Fixing invalid simpcat dependency and updating spec

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,17 @@
 ---
 fixtures:
   repositories:
-    simp_apache: "https://github.com/simp/pupmod-simp-apache"
     auditd: "https://github.com/simp/pupmod-simp-auditd"
+    augeasproviders_core:
+      repo: "https://github.com/simp/augeasproviders_core"
+      branch: "simp-master"
+    augeasproviders_grub:
+      repo: "https://github.com/simp/augeasproviders_grub"
+      branch: "simp-master"
+    compliance: "https://github.com/simp/pupmod-simp-compliance_markup"
+    haveged:
+      repo: "https://github.com/simp/puppet-haveged"
+      branch: "simp-master"
     iptables: "https://github.com/simp/pupmod-simp-iptables"
     logrotate: "https://github.com/simp/pupmod-simp-logrotate"
     pki: "https://github.com/simp/pupmod-simp-pki"
@@ -10,6 +19,7 @@ fixtures:
     rsyslog: "https://github.com/simp/pupmod-simp-rsyslog"
     simpcat: "https://github.com/simp/pupmod-simp-simpcat"
     simplib: "https://github.com/simp/pupmod-simp-simplib"
+    simp_apache: "https://github.com/simp/pupmod-simp-simp_apache"
     stdlib:
       repo: "https://github.com/simp/puppetlabs-stdlib"
       branch: "simp-master"

--- a/manifests/web/add_user.pp
+++ b/manifests/web/add_user.pp
@@ -24,12 +24,6 @@ define ganglia::web::add_user (
   $realm = ''
 ){
 
-  if !defined(Simpcat_build['gweb']) {
-    simpcat_build { 'gweb':
-      order => ['*.user']
-    }
-  }
-
   simpcat_fragment { "gweb+$name.user":
     content => template('ganglia/web/user.erb')
   }

--- a/manifests/web/conf.pp
+++ b/manifests/web/conf.pp
@@ -113,8 +113,14 @@ class ganglia::web::conf (
 ) {
   include 'ganglia::web'
 
-  apache::add_site { 'ganglia':
+  simp_apache::add_site { 'ganglia':
     content => template('ganglia/web/apache.erb')
+  }
+
+  if !defined(Simpcat_build['gweb']) {
+    simpcat_build { 'gweb':
+      order => ['*.user']
+    }
   }
 
   $outfile = simpcat_output('gweb')

--- a/spec/classes/web/conf_spec.rb
+++ b/spec/classes/web/conf_spec.rb
@@ -1,14 +1,12 @@
 require 'spec_helper'
 
-describe 'ganglia::web' do
+describe 'ganglia::web::conf' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:facts) { facts }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_package('gweb') }
-        it { is_expected.to contain_package('php') }
       end
     end
   end


### PR DESCRIPTION
- web/conf.pp requires Simpcat_build['gweb'], which is contained in
  web/add_user.pp. This is bad.
- converted apache::add_site to simp_apache::add_site

SIMP-1723 #close
